### PR TITLE
Clarify that you can use HTML if there is no templating support

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These are the tools officially supported by the Design System team in GDS.
 - [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)
 
 ### HTML
-You can copy and paste use the HTML examples into your project if there is no templating support.
+You can copy and paste the HTML examples into your project if there is no templating support.
 
 ### Node.js
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) - supports Nunjucks templating language for Node.js

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ These are the tools officially supported by the Design System team in GDS.
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend)
 - [GOV.UK Prototype Kit](https://govuk-prototype-kit.herokuapp.com/docs)
 
+### HTML
+You can copy and paste use the HTML examples into your project if there is no templating support.
+
 ### Node.js
 - [GOV.UK Frontend](https://github.com/alphagov/govuk-frontend) - supports Nunjucks templating language for Node.js
 


### PR DESCRIPTION
Clarify that you can use HTML if there is no templating support.

Sometimes people think they have to use Nunjucks macros but you can copy the HTML.