### PR TITLE
Added govuk-react-jsx

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Examples:
 
 ### React
 - [govuk-react/govuk-react](https://github.com/govuk-react/govuk-react) - GOV.UK Design System in React using CSSinJS
+- [govuk-react-jsx](https://github.com/surevine/govuk-react-jsx) - A port of the govuk-frontend Nunjucks to lightweight JSX (Directly consuming govuk CSS/JS). See readme for more detailed comparison with govuk-react.
 
 ### Ruby
 


### PR DESCRIPTION
Added govuk-react-jsx to the list of React libraries. The readme at https://github.com/surevine/govuk-react-jsx contains details of the motivation for the project as well as a comparison of this vs govuk-react